### PR TITLE
Use sha256 for comparing

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ Creates backups when exiting the editor.
 
 Adds a timestamp to the backup name. This allows historical backups to be created.
 
-* *NONE* - Adds no extra timestamp which would only ever create 1 backup.
-* *DATE* - Appends *YYYYMMDD* to the backup name allowing snapshots to be generated daily.
-* *EPOCH* - Appends the number of milliseconds that have passed since EPOCH allowing new backups generate on each exit.
+* `NONE` - Adds no extra timestamp which would only ever create 1 backup.
+* `DATE` - Appends *YYYYMMDD* to the backup name allowing snapshots to be generated daily.
+* `EPOCH` - Appends the number of milliseconds that have passed since EPOCH which will generate a unique backup each time.
 
 ### Max Threads
 
-The backups are created using threads. Using -1 will use all processors available to do the backup quickly. Using 0 or 1 will avoid creating entirely.
+The backups are created using threads. Using `-1` will use all processors available to do the backup quickly. Using `0` or `1` will avoid creating entirely.
 
 ## Tool Menu
 

--- a/addons/local-backup/plugin.gd
+++ b/addons/local-backup/plugin.gd
@@ -50,18 +50,12 @@ class ReplaceFile:
 		self.from = from
 		self.to = to
 
-	func read_all(path: String) -> PoolByteArray:
-		var file := File.new()
-		if OK != file.open(path, File.READ):
-			return PoolByteArray()
-		return file.get_buffer(file.get_len())
-
 	func do_work() -> void:
-		var src := read_all(from)
-		var dst := read_all(to)
-		if src.size() == dst.size():
-			if src == dst:
-				return
+		var file := File.new()
+		var src := file.get_sha256(from)
+		var dst := file.get_sha256(to)
+		if src == dst:
+			return
 
 		var copy := CopyFile.new(from, to)
 		copy.do_work()


### PR DESCRIPTION
It's much faster to just use sha256 to compare the file text because there is no memory allocation